### PR TITLE
Unconfirmed account warning improvements

### DIFF
--- a/actions/auth/login.ts
+++ b/actions/auth/login.ts
@@ -40,7 +40,7 @@ export const loginWithEmailAndPassword = async (
             error: JSON.stringify(error)
         }
     }
-    revalidatePath('/');
+    revalidatePath('/', 'layout');
     return {
         success: true,
     }
@@ -81,7 +81,7 @@ export const loginWithTempToken = async (
             }
         }
     }
-    revalidatePath('/');
+    revalidatePath('/', 'layout');
     return {
         success: true,
     }
@@ -117,7 +117,7 @@ export const loginWithOTP = async (otp: string) => {
             }
         }
     }
-    revalidatePath('/');
+    revalidatePath('/', 'layout');
     return {
         success: true,
     }
@@ -154,7 +154,7 @@ export const forceRefreshToken = async () => {
             }
         }
     }
-    revalidatePath('/');
+    revalidatePath('/', 'layout');
     return {
         success: true,
     }

--- a/app/[locale]/(default)/auth/otp/_components/otp-form.tsx
+++ b/app/[locale]/(default)/auth/otp/_components/otp-form.tsx
@@ -91,6 +91,7 @@ const OtpForm: React.FC<OtpFormProps> = (props) => {
                 });
                 return;
             }
+            router.refresh();
             setSuccess(true);
         });
     }

--- a/app/[locale]/(default)/settings/phone/verify/_components/VerificationForm.tsx
+++ b/app/[locale]/(default)/settings/phone/verify/_components/VerificationForm.tsx
@@ -90,6 +90,7 @@ const VerificationForm: React.FC<VerificationFormProps> = (props) => {
                 });
                 return;
             }
+            router.refresh();
             setSuccess(true);
         });
     }

--- a/components/unconfirmed-account-warning.tsx
+++ b/components/unconfirmed-account-warning.tsx
@@ -19,7 +19,11 @@ const UnconfirmedAccountWarning: React.FC = async () => {
             <Container>
                 <div className='flex gap-4 items-center'>
                     <span>
-                        <AlertTriangle className='size-8' />
+                        <AlertTriangle
+                            className='size-8'
+                            aria-label={t('alertTriangleAriaLabel')}
+                            role='img'
+                        />
                     </span>
                     <p role="alert"
                         className='text-sm font-semibold'
@@ -29,8 +33,10 @@ const UnconfirmedAccountWarning: React.FC = async () => {
                     </p>
                 </div>
 
-                <div className='bg-secondary px-2 mt-2 rounded-md w-fit'>
-                    <LinkButton href="/link/verify-contact">
+                <div className='bg-secondary px-4 mt-2 rounded-md w-fit'>
+                    <LinkButton href="/link/verify-contact"
+                        className='text-secondary-foreground'
+                    >
                         {t('openVerificationPage')}
                     </LinkButton>
                 </div>

--- a/i18n/translations/nl.json
+++ b/i18n/translations/nl.json
@@ -6,6 +6,7 @@
     "Index": {
         "skipToMainContentBtn": "Ga naar de hoofdinhoud",
         "unconfirmedAccountWarning": {
+            "alertTriangleAriaLabel": "Let op",
             "warnText": "Bevestig nu eerst je account. Controleer je e-mail, daarin vind je een aanmeld-link om je account te bevestigen. Onbevestigde accounts worden na 7 dagen automatisch verwijderd.",
             "openVerificationPage": "Geen registratie e-mail ontvangen?"
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication post-login cache invalidation and client refresh behavior, which can affect session visibility and navigation, but changes are small and localized.
> 
> **Overview**
> Updates all server-side login actions to `revalidatePath('/', 'layout')` so the root layout is revalidated after successful authentication.
> 
> After OTP verification (both the auth OTP flow and phone verification flow), the client now calls `router.refresh()` to immediately reflect the new session state.
> 
> Improves the unconfirmed-account warning by adding accessible labeling to the alert icon and tweaking the CTA styling, plus adds the new Dutch translation key `Index.unconfirmedAccountWarning.alertTriangleAriaLabel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e746fdb0fe0d7271ba3a785de4d5cb07c4778096. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->